### PR TITLE
Fix zIndex on modals

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -88,7 +88,9 @@ const handleInputKeyDown = (
 };
 
 const handleDeleteChip = (value, onDeleteItem, inputRef) => () => {
-  if (!onDeleteItem) return;
+  if (!onDeleteItem) {
+    return;
+  }
   onDeleteItem(value);
   inputRef.focus();
 };
@@ -101,7 +103,9 @@ const handleOnClickItem = (
   setSuggestionsRef,
   inputValue
 ) => () => {
-  if (!onSelectItem) return;
+  if (!onSelectItem) {
+    return;
+  }
   onSelectItem(suggestion);
   handleCloseSuggestions(setAnchorEl, setSuggestionsRef)();
   inputValue('');
@@ -116,6 +120,7 @@ const handleCloseSuggestions = (setAnchorEl, setSuggestionsRef) => () => {
 const AutoComplete = ({
   inputProps,
   paperProps,
+  containerProps,
   itemProps,
   values,
   onDeleteItem,
@@ -134,7 +139,7 @@ const AutoComplete = ({
   const open = Boolean(anchorEl);
 
   return (
-    <div className={classes.root} ref={setContainerRef}>
+    <div className={classes.root} ref={setContainerRef} {...containerProps}>
       <Input
         name="inputValue"
         value={inputValue}
@@ -165,6 +170,10 @@ const AutoComplete = ({
         style={{
           width: containerRef ? containerRef.offsetWidth : null,
           marginLeft: '20px',
+          zIndex:
+            containerRef && containerRef.style
+              ? containerRef.style.zIndex
+              : null,
         }}
       >
         <Paper className={classes.paper} {...paperProps}>

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -120,7 +120,6 @@ const handleCloseSuggestions = (setAnchorEl, setSuggestionsRef) => () => {
 const AutoComplete = ({
   inputProps,
   paperProps,
-  containerProps,
   itemProps,
   values,
   onDeleteItem,
@@ -139,7 +138,7 @@ const AutoComplete = ({
   const open = Boolean(anchorEl);
 
   return (
-    <div className={classes.root} ref={setContainerRef} {...containerProps}>
+    <div className={classes.root} ref={setContainerRef}>
       <Input
         name="inputValue"
         value={inputValue}
@@ -170,10 +169,7 @@ const AutoComplete = ({
         style={{
           width: containerRef ? containerRef.offsetWidth : null,
           marginLeft: '20px',
-          zIndex:
-            containerRef && containerRef.style
-              ? containerRef.style.zIndex
-              : null,
+          zIndex: 1500,
         }}
       >
         <Paper className={classes.paper} {...paperProps}>


### PR DESCRIPTION
**Problema:**  O Popper do componente AutoComplete fica por baixo quando usado em um modal (Dialog).

**Solução:** Como a questão de zIndex é bem sensível e varia dependendo de como e onde o componente é utilizado, por isso optei por apenas dar o suporte para quem utiliza o componente poder ajudar seu container como achar adequado. Para isso foi adicionado o `containerProps` fazendo com que seja possível passar propriedades para o container onde o autocomplete será renderizado. Dessa maneira é possível customizar não só o styles, mas bem como outras propriedades do container que sejam necessárias.